### PR TITLE
removed unnecessary calls to set_solver_print in ExecComp notebook

### DIFF
--- a/openmdao_book/features/building_blocks/components/exec_comp.ipynb
+++ b/openmdao_book/features/building_blocks/components/exec_comp.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
@@ -36,38 +36,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead>\n",
-       "<tr><th>Option           </th><th>Default  </th><th>Acceptable Values  </th><th>Acceptable Types        </th><th>Description                                                                                                                                                                 </th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>distributed      </td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>True if ALL variables in this component are distributed across multiple processes.                                                                                          </td></tr>\n",
-       "<tr><td>has_diag_partials</td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>If True, treat all array/array partials as diagonal if both arrays have size &gt; 1. All arrays with size &gt; 1 must have the same flattened size or an exception will be raised.</td></tr>\n",
-       "<tr><td>run_root_only    </td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>If True, call compute/compute_partials/linearize/apply_linear/apply_nonlinear/compute_jacvec_product only on rank 0 and broadcast the results to the other ranks.           </td></tr>\n",
-       "<tr><td>shape            </td><td>N/A      </td><td>N/A                </td><td>[&#x27;int&#x27;, &#x27;tuple&#x27;, &#x27;list&#x27;]</td><td>Shape to be assigned to all variables in this component. Default is None, which means shape may be provided for variables individually.                                     </td></tr>\n",
-       "<tr><td>shape_by_conn    </td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>If True, shape all inputs and outputs based on their connection. Default is False.                                                                                          </td></tr>\n",
-       "<tr><td>units            </td><td>N/A      </td><td>N/A                </td><td>[&#x27;str&#x27;]                 </td><td>Units to be assigned to all variables in this component. Default is None, which means units may be provided for variables individually.                                     </td></tr>\n",
-       "</tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "om.show_options_table(\"openmdao.components.exec_comp.ExecComp\")"
    ]
@@ -150,17 +125,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[3.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "prob = om.Problem()\n",
     "model = prob.model\n",
@@ -178,25 +145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -214,18 +170,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[3.]\n",
-      "[1.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "prob = om.Problem()\n",
     "model = prob.model\n",
@@ -244,25 +191,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(prob.get_val('comp.y1'), 3.0, 0.00001)\n",
     "assert_near_equal(prob.get_val('comp.y2'), 1.0, 0.00001)"
@@ -282,17 +218,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -312,25 +240,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(prob.get_val('comp.y'), 2.0, 0.00001)"
    ]
@@ -346,17 +263,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -377,25 +286,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(prob.get_val('comp.z'), 1.0, 0.00001)"
    ]
@@ -413,17 +311,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[24.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "prob = om.Problem()\n",
     "model = prob.model\n",
@@ -445,25 +335,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(prob.get_val('comp.z'), 24.0, 0.00001)"
    ]
@@ -483,21 +362,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 3. -0. -0. -0. -0.]\n",
-      " [-0.  3. -0. -0. -0.]\n",
-      " [-0. -0.  3. -0. -0.]\n",
-      " [-0. -0. -0.  3. -0.]\n",
-      " [-0. -0. -0. -0.  3.]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -521,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
@@ -549,17 +416,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2. 4.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "model = om.Group()\n",
     "\n",
@@ -579,25 +438,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(prob.get_val('comp.y'), [2., 4.], 0.00001)"
    ]
@@ -614,17 +462,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try: \n",
     "    om.ExecComp.register(\"myfunc\", lambda x: x * x, complex_safe=True)\n",
@@ -641,25 +481,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(J['comp.y', 'comp.x'][0][0], 4., 1e-10)"
    ]
@@ -677,17 +506,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4.000001999848735\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    om.ExecComp.register(\"unsafe\", lambda x: x * x, complex_safe=False)\n",
@@ -708,25 +529,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4.999621836532242e-07"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(J['comp.y', 'comp.x'][0][0], 4., 1e-5)"
    ]
@@ -742,18 +552,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[8.7]\n",
-      "[3.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -780,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",

--- a/openmdao_book/features/building_blocks/components/exec_comp.ipynb
+++ b/openmdao_book/features/building_blocks/components/exec_comp.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "remove-input",
@@ -24,7 +24,6 @@
    "metadata": {},
    "source": [
     "# ExecComp\n",
-    "",
     "\n",
     "\n",
     "`ExecComp` is a component that provides a shortcut for building an ExplicitComponent that\n",
@@ -32,19 +31,43 @@
     "automatically takes care of all of the component API methods, so you just need to instantiate\n",
     "it with an equation or a list of equations.\n",
     "\n",
-    "## ExecComp Options\n",
-    ""
+    "## ExecComp Options\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "tags": [
      "remove-input"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>Option           </th><th>Default  </th><th>Acceptable Values  </th><th>Acceptable Types        </th><th>Description                                                                                                                                                                 </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td>distributed      </td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>True if ALL variables in this component are distributed across multiple processes.                                                                                          </td></tr>\n",
+       "<tr><td>has_diag_partials</td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>If True, treat all array/array partials as diagonal if both arrays have size &gt; 1. All arrays with size &gt; 1 must have the same flattened size or an exception will be raised.</td></tr>\n",
+       "<tr><td>run_root_only    </td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>If True, call compute/compute_partials/linearize/apply_linear/apply_nonlinear/compute_jacvec_product only on rank 0 and broadcast the results to the other ranks.           </td></tr>\n",
+       "<tr><td>shape            </td><td>N/A      </td><td>N/A                </td><td>[&#x27;int&#x27;, &#x27;tuple&#x27;, &#x27;list&#x27;]</td><td>Shape to be assigned to all variables in this component. Default is None, which means shape may be provided for variables individually.                                     </td></tr>\n",
+       "<tr><td>shape_by_conn    </td><td>False    </td><td>[True, False]      </td><td>[&#x27;bool&#x27;]                </td><td>If True, shape all inputs and outputs based on their connection. Default is False.                                                                                          </td></tr>\n",
+       "<tr><td>units            </td><td>N/A      </td><td>N/A                </td><td>[&#x27;str&#x27;]                 </td><td>Units to be assigned to all variables in this component. Default is None, which means units may be provided for variables individually.                                     </td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "om.show_options_table(\"openmdao.components.exec_comp.ExecComp\")"
    ]
@@ -54,7 +77,6 @@
    "metadata": {},
    "source": [
     "## ExecComp Constructor\n",
-    "",
     "\n",
     "The call signature for the `ExecComp` constructor is:\n",
     "\n",
@@ -108,7 +130,6 @@
     "- :ref:`add_output <openmdao.core.component.Component.add_output>`\n",
     "\n",
     "## Registering User Functions\n",
-    "",
     "\n",
     "To get your own functions added to the internal namespace of ExecComp so you can call them\n",
     "from within an ExecComp expression, you can use the `ExecComp.register` function.\n",
@@ -123,16 +144,23 @@
     "\n",
     "\n",
     "ExecComp Example: Simple\n",
-    "",
     "\n",
     "For example, here is a simple component that takes the input and adds one to it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3.]\n"
+     ]
+    }
+   ],
    "source": [
     "prob = om.Problem()\n",
     "model = prob.model\n",
@@ -143,7 +171,6 @@
     "\n",
     "prob.setup()\n",
     "\n",
-    "prob.set_solver_print(level=0)\n",
     "prob.run_model()\n",
     "\n",
     "print(prob.get_val('comp.y'))"
@@ -151,14 +178,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -170,16 +208,24 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Multiple Outputs\n",
-    "",
     "\n",
     "You can also create an ExecComp with multiple outputs by placing the expressions in a list."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3.]\n",
+      "[1.]\n"
+     ]
+    }
+   ],
    "source": [
     "prob = om.Problem()\n",
     "model = prob.model\n",
@@ -190,7 +236,6 @@
     "\n",
     "prob.set_val('x', 2.0)\n",
     "\n",
-    "prob.set_solver_print(level=0)\n",
     "prob.run_model()\n",
     "\n",
     "print(prob.get_val('comp.y1'))\n",
@@ -199,14 +244,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('comp.y1'), 3.0, 0.00001)\n",
     "assert_near_equal(prob.get_val('comp.y2'), 1.0, 0.00001)"
@@ -217,7 +273,6 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Arrays\n",
-    "",
     "\n",
     "You can declare an ExecComp with arrays for inputs and outputs, but when you do, you must also\n",
     "pass in a correctly-sized array as an argument to the ExecComp call, or set the 'shape' metadata\n",
@@ -227,9 +282,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2.]\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -242,7 +305,6 @@
     "\n",
     "prob.setup()\n",
     "\n",
-    "prob.set_solver_print(level=0)\n",
     "prob.run_model()\n",
     "\n",
     "print(prob.get_val('comp.y'))"
@@ -250,14 +312,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('comp.y'), 2.0, 0.00001)"
    ]
@@ -267,16 +340,23 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Math Functions\n",
-    "",
     "\n",
     "Functions from the math library are available for use in the expression strings."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1.]\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -290,7 +370,6 @@
     "prob.set_val('comp.x', np.pi/2.0)\n",
     "prob.set_val('comp.y', np.pi/2.0)\n",
     "\n",
-    "prob.set_solver_print(level=0)\n",
     "prob.run_model()\n",
     "\n",
     "print(prob.get_val('comp.z'))"
@@ -298,14 +377,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('comp.z'), 1.0, 0.00001)"
    ]
@@ -315,7 +405,6 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Variable Properties\n",
-    "",
     "\n",
     "You can also declare properties like 'units', 'upper', or 'lower' on the inputs and outputs. In this\n",
     "example we declare all our inputs to be inches to trigger conversion from a variable expressed in feet\n",
@@ -324,9 +413,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[24.]\n"
+     ]
+    }
+   ],
    "source": [
     "prob = om.Problem()\n",
     "model = prob.model\n",
@@ -341,7 +438,6 @@
     "prob.set_val('comp.x', 12.0, units='inch')\n",
     "prob.set_val('comp.y', 1.0, units='ft')\n",
     "\n",
-    "prob.set_solver_print(level=0)\n",
     "prob.run_model()\n",
     "\n",
     "print(prob.get_val('comp.z'))"
@@ -349,14 +445,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('comp.z'), 24.0, 0.00001)"
    ]
@@ -366,7 +473,6 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Diagonal Partials\n",
-    "",
     "\n",
     "If all of your ExecComp's array inputs and array outputs are the same size and happen to have\n",
     "diagonal partials, you can make computation of derivatives for your ExecComp faster by specifying a\n",
@@ -377,9 +483,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 3. -0. -0. -0. -0.]\n",
+      " [-0.  3. -0. -0. -0.]\n",
+      " [-0. -0.  3. -0. -0.]\n",
+      " [-0. -0. -0.  3. -0.]\n",
+      " [-0. -0. -0. -0.  3.]]\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -403,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "tags": [
      "remove-input",
@@ -422,7 +540,6 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Options\n",
-    "",
     "\n",
     "Other options that can apply to all the variables in the component are variable shape and units.\n",
     "These can also be set as a keyword argument in the constructor or via the component options. In the\n",
@@ -432,9 +549,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2. 4.]\n"
+     ]
+    }
+   ],
    "source": [
     "model = om.Group()\n",
     "\n",
@@ -454,14 +579,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('comp.y'), [2., 4.], 0.00001)"
    ]
@@ -471,7 +607,6 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: User function registration\n",
-    "",
     "\n",
     "If the function is complex safe, then you don't need to do anything differently than you\n",
     "would for any other ExecComp."
@@ -479,9 +614,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.0\n"
+     ]
+    }
+   ],
    "source": [
     "try: \n",
     "    om.ExecComp.register(\"myfunc\", lambda x: x * x, complex_safe=True)\n",
@@ -498,14 +641,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(J['comp.y', 'comp.x'][0][0], 4., 1e-10)"
    ]
@@ -515,7 +669,6 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Complex unsafe user function registration\n",
-    "",
     "\n",
     "If the function isn't complex safe, then derivatives involving that function\n",
     "will have to be computed using finite difference instead of complex step.  The way to specify\n",
@@ -524,9 +677,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.000001999848735\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    om.ExecComp.register(\"unsafe\", lambda x: x * x, complex_safe=False)\n",
@@ -547,14 +708,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4.999621836532242e-07"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(J['comp.y', 'comp.x'][0][0], 4., 1e-5)"
    ]
@@ -564,16 +736,24 @@
    "metadata": {},
    "source": [
     "## ExecComp Example: Adding Expressions\n",
-    "",
     "\n",
     "You can add additional expressions to an `ExecComp` with the \"add_expr\" method."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[8.7]\n",
+      "[3.]\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -600,7 +780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "tags": [
      "remove-input",


### PR DESCRIPTION
ExecComp examples had unnecessary `set_solver_print` calls despite having the default solver.